### PR TITLE
skip C.UTF-8 nad POSIX.UTF-8 too

### DIFF
--- a/t/lib/gen_test_data.pl
+++ b/t/lib/gen_test_data.pl
@@ -28,11 +28,11 @@ sub gen {
 		skip("cannot run test without a locale set", 0);
 		exit 0;
 	}
-	if ($messages eq 'C') {
+	if ($messages =~ /^C(\..*)?$/) {
 		skip("cannot run test in the C locale", 0);
 		exit 0;
 	}
-	if ($messages eq 'POSIX') {
+	if ($messages =~ /^POSIX(\..*)?$/) {
 		skip("cannot run test in the POSIX locale", 0);
 		exit 0;
 	}


### PR DESCRIPTION
Tests were being skipped when locale was set to `C` or `POSIX` but they were not skipped for `C.UTF-8` (which appears on MS-Windows).

This patch change the test scripts to also skip tests for any locale matching `C` or `POSIX` following for a dot and any additional string.